### PR TITLE
Fix dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "electrical/file_concat",
-      "version_requirement": "1.x"
+      "version_requirement": ">= 1.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -15,11 +15,11 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": "1.x"
+      "version_requirement": ">= 1.0"
     },
     {
       "name": "electrical/file_concat",
-      "version_requirement": ">= 1.0"
+      "version_requirement": "1.x"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Changed puppetlabs-concat requirement from requiring a version v1.x to > v1.0 as v2.0 of puppetlabs-concat is backwards compatible.